### PR TITLE
add maven support

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,13 +1,19 @@
 ---
--   id: license-check-pipenv
-    name: Check the licenses of the pipenv environment
-    description: This hook scans the local Pipfile against a configured list of allowed open source licenses.
-    entry: license-check-pipenv
-    files: Pipfile
-    language: python
--   id: license-check-npm
-    name: Check the licenses of the npm environment.
-    description: This hook scans the package. a configured list of allowed open source licenses.
-    entry: license-check-npm
-    files: package.json
-    language: python
+- id: license-check-maven
+  name: Check the licenses of the maven environment.
+  description: This hook scans the the maven dependency list againt a configured list of allowed open source licenses.
+  entry: license-check-npm
+  files: pom.xml
+  language: python
+- id: license-check-npm
+  name: Check the licenses of the npm environment.
+  description: This hook scans the package. a configured list of allowed open source licenses.
+  entry: license-check-npm
+  files: package.json
+  language: python
+- id: license-check-pipenv
+  name: Check the licenses of the pipenv environment
+  description: This hook scans the local Pipfile against a configured list of allowed open source licenses.
+  entry: license-check-pipenv
+  files: Pipfile
+  language: python

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
 - id: license-check-maven
   name: Check the licenses of the maven environment.
   description: This hook scans the the maven dependency list againt a configured list of allowed open source licenses.
-  entry: license-check-npm
+  entry: license-check-maven
   files: pom.xml
   language: python
 - id: license-check-npm

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ compliance in the python ecosystem.
 
 - [pre-commit-license-checks](#pre-commit-license-checks)
   - [Installation](#installation)
+  - [Configuration](#configuration)
   - [Available hooks](#available-hooks)
+    - [`license-check-maven`](#license-check-maven)
     - [`license-check-npm`](#license-check-npm)
     - [`license-check-pipenv`](#license-check-pipenv)
   - [Contributing](#contributing)
@@ -38,18 +40,11 @@ repos:
       - id: license-check-pipenv
 ```
 
-## Available hooks
+## Configuration
 
-### `license-check-npm`
-
-**What it does**
-
-* This hook checks the licenses of your dependencies declared in a `package.json` against defined list of allowed open
-  source licenses.
-
-**Configuration**
-
-To configure the list of allowed licenses, put a file called `.license-check.yaml` alongside your `package.json`.
+All hooks in this repository share a common configuration file format. To configure the list of allowed licenses, put a
+file called `.license-check.yaml` alongside the file containing the declaration of you dependencies (e.g. `package.json`
+. `pom.xml`, ...).
 
 The file must be structured the following way:
 
@@ -75,6 +70,27 @@ excludedPackages:
   - check
   - ...
 ```
+
+## Available hooks
+
+### `license-check-maven`
+
+**What it does**
+
+* This hook checks the licenses of your maven dependencies declared in a `pom.xml` against defined list of allowed open
+  source licenses.
+
+**More info**
+
+* [maven](https://maven.apache.org/)
+* [license-maven-plugin](https://www.mojohaus.org/license-maven-plugin/)
+
+### `license-check-npm`
+
+**What it does**
+
+* This hook checks the licenses of your dependencies declared in a `package.json` against defined list of allowed open
+  source licenses.
 
 **More info**
 
@@ -87,35 +103,6 @@ excludedPackages:
 
 * This hook checks the contents of a [pipenv](https://pypi.org/project/pipenv/) environment against a defined list of
   allowed open source licenses.
-
-**Configuration**
-
-To configure the list of allowed licenses, put a file called `.license-check.yaml` alongside your `Pipfile`.
-
-The file must be structured the following way:
-
-```yaml
----
-allowedLicenses:
-  - a
-  - list
-  - of
-  - allowed
-  - licenses
-  - ...
-excludedPackages:
-  - any
-  - package
-  - listed
-  - here
-  - will
-  - be
-  - excluded
-  - from
-  - the
-  - check
-  - ...
-```
 
 **More info**
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     packages=find_packages(where='src'),
     entry_points={
         'console_scripts': [
+            'license-check-maven = license_checks.maven:main',
             'license-check-npm = license_checks.npm:main',
             'license-check-pipenv = license_checks.pipenv:main',
         ],

--- a/src/license_checks/base_checker.py
+++ b/src/license_checks/base_checker.py
@@ -25,13 +25,13 @@ class BaseLicenseChecker(metaclass=abc.ABCMeta):
         """Return the command needed to run in the target directory"""
 
     @abc.abstractmethod
-    def parse_packages(self, output: str, configuration: dict) -> List[Package]:
+    def parse_packages(self, output: str, configuration: dict, directory: str) -> List[Package]:
         """Parse the licenses from the output of the checker program."""
 
     def load_installed_packages(self, directory: str, configuration: dict) -> List[Package]:
         result = run(self.get_license_checker_command(), capture_output=True, check=True, cwd=directory,
                      shell=True, text=True)
-        return self.parse_packages(result.stdout, configuration)
+        return self.parse_packages(result.stdout, configuration, directory)
 
     def consolidate_directories(self, filenames) -> List[str]:
         directories = []

--- a/src/license_checks/base_checker.py
+++ b/src/license_checks/base_checker.py
@@ -21,7 +21,7 @@ class BaseLicenseChecker(metaclass=abc.ABCMeta):
         """Prepare the directory for the license check, e.g. by installing all needed tools."""
 
     @abc.abstractmethod
-    def get_license_checker_command(self) -> str:
+    def get_license_checker_command(self, directory: str) -> str:
         """Return the command needed to run in the target directory"""
 
     @abc.abstractmethod
@@ -29,7 +29,7 @@ class BaseLicenseChecker(metaclass=abc.ABCMeta):
         """Parse the licenses from the output of the checker program."""
 
     def load_installed_packages(self, directory: str, configuration: dict) -> List[Package]:
-        result = run(self.get_license_checker_command(), capture_output=True, check=True, cwd=directory,
+        result = run(self.get_license_checker_command(directory), capture_output=True, check=True, cwd=directory,
                      shell=True, text=True)
         return self.parse_packages(result.stdout, configuration, directory)
 

--- a/src/license_checks/maven.py
+++ b/src/license_checks/maven.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import sys
 from json import loads
-from subprocess import run
 from typing import List
 
 from license_checks.base_checker import BaseLicenseChecker
@@ -9,15 +8,13 @@ from license_checks.configuration import Configuration
 from license_checks.configuration.package import Package
 
 
-# TODO: ignore pip-licenses
-class PipenvLicenseChecker(BaseLicenseChecker):
+class MavenLicenseChecker(BaseLicenseChecker):
     def prepare_directory(self, directory: str):
-        run('pipenv install -d', capture_output=not self.debug, check=True, cwd=directory, shell=True)
-        run("pipenv run pip install 'pip-licenses==3.3.1'", capture_output=not self.debug, check=True, cwd=directory,
-            shell=True)
+        pass
 
     def get_license_checker_command(self) -> str:
-        return 'pipenv run pip-licenses --format=json'
+        # TODO: don't use wrapper when not present
+        return './mvnw org.codehaus.mojo:license-maven-plugin:2.0.0:download-licenses'
 
     def parse_packages(self, output: str, configuration: Configuration, directory: str) -> List[Package]:
         values = loads(output)
@@ -32,7 +29,7 @@ class PipenvLicenseChecker(BaseLicenseChecker):
 
 
 def main():
-    sys.exit(PipenvLicenseChecker().run(sys.argv[1:]))
+    sys.exit(MavenLicenseChecker().run(sys.argv[1:]))
 
 
 if __name__ == '__main__':

--- a/src/license_checks/maven.py
+++ b/src/license_checks/maven.py
@@ -14,9 +14,10 @@ class MavenLicenseChecker(BaseLicenseChecker):
     def prepare_directory(self, directory: str):
         pass
 
-    def get_license_checker_command(self) -> str:
+    def get_license_checker_command(self, directory: str) -> str:
+        wrapper = join(directory, 'mvnw')
         # TODO: don't use wrapper when not present
-        return 'mvnw org.codehaus.mojo:license-maven-plugin:2.0.0:download-licenses'
+        return f'{wrapper} org.codehaus.mojo:license-maven-plugin:2.0.0:download-licenses'
 
     def parse_packages(self, output: str, configuration: Configuration, directory: str) -> List[Package]:
         packages = []
@@ -39,7 +40,6 @@ class MavenLicenseChecker(BaseLicenseChecker):
                 version.text,
                 ';'.join(license_names)
             ))
-            print(group_id.text)
 
         return packages
 

--- a/src/license_checks/maven.py
+++ b/src/license_checks/maven.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import sys
-from os.path import join
+from os.path import join, exists
 from typing import List
 from xml.etree import ElementTree
 
@@ -15,9 +15,13 @@ class MavenLicenseChecker(BaseLicenseChecker):
         pass
 
     def get_license_checker_command(self, directory: str) -> str:
-        wrapper = join(directory, 'mvnw')
-        # TODO: don't use wrapper when not present
-        return f'{wrapper} org.codehaus.mojo:license-maven-plugin:2.0.0:download-licenses'
+        wrapper_path = join(directory, 'mvnw')
+
+        binary = 'mvn'
+        if exists(wrapper_path):
+            binary = wrapper_path
+
+        return f'{binary} org.codehaus.mojo:license-maven-plugin:2.0.0:download-licenses'
 
     def parse_packages(self, output: str, configuration: Configuration, directory: str) -> List[Package]:
         packages = []

--- a/src/license_checks/maven.py
+++ b/src/license_checks/maven.py
@@ -26,7 +26,7 @@ class MavenLicenseChecker(BaseLicenseChecker):
     def parse_packages(self, output: str, configuration: Configuration, directory: str) -> List[Package]:
         packages = []
 
-        licenses_file_path = join(directory, 'target', 'licenses.xml')
+        licenses_file_path = join(directory, 'target', 'generated-resources', 'licenses.xml')
         tree = ElementTree.parse(licenses_file_path)
         root = tree.getroot()
         for dependency in root.findall('./dependencies/dependency'):

--- a/src/license_checks/npm.py
+++ b/src/license_checks/npm.py
@@ -17,7 +17,7 @@ class NpmLicenseChecker(BaseLicenseChecker):
         # pretty hard to parse.
         return 'npx license-checker --csv'
 
-    def parse_packages(self, output: str, configuration: dict) -> List[Package]:
+    def parse_packages(self, output: str, configuration: dict, directory: str) -> List[Package]:
         packages = []
         package_reader = csv.DictReader(output.splitlines())
         for row in package_reader:

--- a/src/license_checks/npm.py
+++ b/src/license_checks/npm.py
@@ -12,7 +12,7 @@ class NpmLicenseChecker(BaseLicenseChecker):
     def prepare_directory(self, directory: str):
         run('npm install --no-audit --no-fund', capture_output=not self.debug, check=True, cwd=directory, shell=True)
 
-    def get_license_checker_command(self) -> str:
+    def get_license_checker_command(self, directory: str) -> str:
         # yes, we are using csv here. license-checker's json output does not build an array of licenses, which is
         # pretty hard to parse.
         return 'npx license-checker --csv'

--- a/src/license_checks/pipenv.py
+++ b/src/license_checks/pipenv.py
@@ -16,7 +16,7 @@ class PipenvLicenseChecker(BaseLicenseChecker):
         run("pipenv run pip install 'pip-licenses==3.3.1'", capture_output=not self.debug, check=True, cwd=directory,
             shell=True)
 
-    def get_license_checker_command(self) -> str:
+    def get_license_checker_command(self, directory: str) -> str:
         return 'pipenv run pip-licenses --format=json'
 
     def parse_packages(self, output: str, configuration: Configuration, directory: str) -> List[Package]:

--- a/tests/integration/test_maven.py
+++ b/tests/integration/test_maven.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from os import environ
+from pathlib import Path
+from shutil import unpack_archive
+from subprocess import run
+from tempfile import TemporaryDirectory, NamedTemporaryFile
+
+import requests
+from git import Repo
+
+from license_checks.configuration import Configuration
+
+
+class TestMavenCheck:
+
+    def setup(self):
+        self.directory = TemporaryDirectory()
+
+        self.prepare_spring_boot_project()
+
+        self.repo = Repo.init(self.directory.name)
+        self.repo.index.add(self.repo.untracked_files)
+
+    def test_run_fails_without_config(self):
+        result = self.run_pre_commit()
+        assert result.returncode == 1
+
+    def test_success(self):
+        Configuration(
+            allowed_licenses=[
+                'Apache 2',
+                'Apache License 2.0',
+                'Apache License, Version 2.0',
+                'BSD',
+                'BSD License 3',
+                'EDL 1.0',
+                'EPL 2.0;GPL2 w/ CPE',
+                'Eclipse Distribution License - v 1.0',
+                'Eclipse Public License - v 1.0;GNU Lesser General Public License',
+                'Eclipse Public License v2.0',
+                'MIT License',
+                'The Apache License, Version 2.0',
+                'The Apache Software License, Version 2.0',
+                'The MIT License'
+            ],
+            excluded_packages=[],
+            includes=[]).save(self.directory.name)
+        result = self.run_pre_commit()
+        print(result.stdout)
+        assert result.returncode == 0
+
+    def run_pre_commit(self):
+        return run(
+            f'pre-commit try-repo {Path(__file__).parent.parent.parent.absolute()} license-check-maven --all-files -v',
+            capture_output=True, cwd=self.directory.name, env=dict(environ, PIPENV_IGNORE_VIRTUALENVS='1'),
+            shell=True)
+
+    def prepare_spring_boot_project(self):
+        with NamedTemporaryFile() as temp_archive:
+            response = requests.post('https://start.spring.io/starter.tgz', data={
+                'dependencies': 'web,devtools',
+                'bootVersion': '2.3.5.RELEASE'
+            })
+            response.raise_for_status()
+            open(temp_archive.name, 'wb').write(response.content)
+
+            unpack_archive(temp_archive.name, self.directory.name, format='gztar')

--- a/tests/unit/test_base_check.py
+++ b/tests/unit/test_base_check.py
@@ -18,7 +18,7 @@ class SimpleLicenseChecker(BaseLicenseChecker):
     def get_license_checker_command(self) -> str:
         return "echo 'Hello World!'"
 
-    def parse_packages(self, output: str, configuration: dict) -> List[Package]:
+    def parse_packages(self, output: str, configuration: dict, directory: str = None) -> List[Package]:
         return [
             Package('starlette', '0.14.1', 'BSD License'),
             Package('demo1234', '0.14.1', 'GPL'),

--- a/tests/unit/test_base_check.py
+++ b/tests/unit/test_base_check.py
@@ -15,7 +15,7 @@ class SimpleLicenseChecker(BaseLicenseChecker):
     def prepare_directory(self, directory: str):
         pass
 
-    def get_license_checker_command(self) -> str:
+    def get_license_checker_command(self, directory: str) -> str:
         return "echo 'Hello World!'"
 
     def parse_packages(self, output: str, configuration: dict, directory: str = None) -> List[Package]:

--- a/tests/unit/test_maven.py
+++ b/tests/unit/test_maven.py
@@ -72,7 +72,8 @@ class TestMavenLicenseChecker:
         self.checker.prepare_directory(self.directory.name)
 
     def test_get_license_checker_command(self):
-        assert self.checker.get_license_checker_command() == './mvnw org.codehaus.mojo:license-maven-plugin:2.0.0:download-licenses'
+        assert self.checker.get_license_checker_command(
+            self.directory.name) == f"{join(self.directory.name, 'mvnw')} org.codehaus.mojo:license-maven-plugin:2.0.0:download-licenses"
 
     def test_parse_packages(self):
         target_directory = join(self.directory.name, 'target')

--- a/tests/unit/test_maven.py
+++ b/tests/unit/test_maven.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from os import mkdir
 from os.path import join
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from license_checks.configuration import Configuration
@@ -72,6 +73,11 @@ class TestMavenLicenseChecker:
         self.checker.prepare_directory(self.directory.name)
 
     def test_get_license_checker_command(self):
+        assert self.checker.get_license_checker_command(
+            self.directory.name) == 'mvn org.codehaus.mojo:license-maven-plugin:2.0.0:download-licenses'
+
+    def test_get_license_checker_command_with_wrapper_present(self):
+        Path(join(self.directory.name, 'mvnw')).touch()
         assert self.checker.get_license_checker_command(
             self.directory.name) == f"{join(self.directory.name, 'mvnw')} org.codehaus.mojo:license-maven-plugin:2.0.0:download-licenses"
 

--- a/tests/unit/test_maven.py
+++ b/tests/unit/test_maven.py
@@ -82,10 +82,10 @@ class TestMavenLicenseChecker:
             self.directory.name) == f"{join(self.directory.name, 'mvnw')} org.codehaus.mojo:license-maven-plugin:2.0.0:download-licenses"
 
     def test_parse_packages(self):
-        target_directory = join(self.directory.name, 'target')
-        mkdir(target_directory)
+        target_directory = Path(self.directory.name, 'target', 'generated-resources')
+        target_directory.mkdir(parents=True)
 
-        with open(join(target_directory, 'licenses.xml'), 'w') as licenses_file:
+        with open(join(target_directory.absolute(), 'licenses.xml'), 'w') as licenses_file:
             licenses_file.write(self.LICENSES_XML)
 
         packages = self.checker.parse_packages('', Configuration(

--- a/tests/unit/test_maven.py
+++ b/tests/unit/test_maven.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from os import mkdir
+from os.path import join
 from tempfile import TemporaryDirectory
 
 from license_checks.configuration import Configuration
@@ -7,11 +9,60 @@ from license_checks.maven import MavenLicenseChecker
 
 
 class TestMavenLicenseChecker:
-    DEMO_LICENSE_OUTPUT = \
-        '''"module name","license","repository"
-"xtend@4.0.2","MIT","https://github.com/Raynos/xtend"
-"y18n@4.0.0","ISC","https://github.com/yargs/y18n"
-"y18n@5.0.5","ISC","https://github.com/yargs/y18n"'''
+    LICENSES_XML = \
+        '''<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<licenseSummary>
+  <dependencies>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.3</version>
+      <licenses>
+        <license>
+          <name>Eclipse Public License - v 1.0</name>
+          <url>http://www.eclipse.org/legal/epl-v10.html</url>
+          <file>eclipse public license - v 1.0 - epl-v10.html</file>
+        </license>
+        <license>
+          <name>GNU Lesser General Public License</name>
+          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html</url>
+          <file>gnu lesser general public license - lgpl-2.1.html</file>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <version>1.2.3</version>
+      <licenses>
+        <license>
+          <name>Eclipse Public License - v 1.0</name>
+          <url>http://www.eclipse.org/legal/epl-v10.html</url>
+          <file>eclipse public license - v 1.0 - epl-v10.html</file>
+        </license>
+        <license>
+          <name>GNU Lesser General Public License</name>
+          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html</url>
+          <file>gnu lesser general public license - lgpl-2.1.html</file>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.11.4</version>
+      <licenses>
+        <license>
+          <name>The Apache Software License, Version 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+          <distribution>repo</distribution>
+          <file>the apache software license, version 2.0 - license-2.0.txt</file>
+        </license>
+      </licenses>
+    </dependency>
+  </dependencies>
+</licenseSummary>
+'''
 
     def setup(self):
         self.directory = TemporaryDirectory()
@@ -24,13 +75,22 @@ class TestMavenLicenseChecker:
         assert self.checker.get_license_checker_command() == './mvnw org.codehaus.mojo:license-maven-plugin:2.0.0:download-licenses'
 
     def test_parse_packages(self):
-        packages = self.checker.parse_packages(self.DEMO_LICENSE_OUTPUT, Configuration(
+        target_directory = join(self.directory.name, 'target')
+        mkdir(target_directory)
+
+        with open(join(target_directory, 'licenses.xml'), 'w') as licenses_file:
+            licenses_file.write(self.LICENSES_XML)
+
+        packages = self.checker.parse_packages('', Configuration(
             allowed_licenses=[],
             excluded_packages=[]
-        ))
+        ),
+                                               self.directory.name)
         assert packages == [
-            Package('xtend', '4.0.2', 'MIT'),
-            Package('y18n', '4.0.0', 'ISC'),
-            Package('y18n', '5.0.5', 'ISC'),
-
+            Package('ch.qos.logback:logback-classic', '1.2.3',
+                    'Eclipse Public License - v 1.0;GNU Lesser General Public License'),
+            Package('ch.qos.logback:logback-core', '1.2.3',
+                    'Eclipse Public License - v 1.0;GNU Lesser General Public License'),
+            Package('com.fasterxml.jackson.core:jackson-annotations', '2.11.4',
+                    'The Apache Software License, Version 2.0')
         ]

--- a/tests/unit/test_maven.py
+++ b/tests/unit/test_maven.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 from tempfile import TemporaryDirectory
-from unittest.mock import patch, call
 
 from license_checks.configuration import Configuration
 from license_checks.configuration.package import Package
-from license_checks.npm import NpmLicenseChecker
+from license_checks.maven import MavenLicenseChecker
 
 
-class TestNpmLicenseChecker:
+class TestMavenLicenseChecker:
     DEMO_LICENSE_OUTPUT = \
         '''"module name","license","repository"
 "xtend@4.0.2","MIT","https://github.com/Raynos/xtend"
@@ -16,26 +15,19 @@ class TestNpmLicenseChecker:
 
     def setup(self):
         self.directory = TemporaryDirectory()
-        self.checker = NpmLicenseChecker()
+        self.checker = MavenLicenseChecker()
 
-    @patch('license_checks.npm.run')
-    def test_prepare_directory(self, run_mock):
-        run_mock.return_value = {}
-
-        with TemporaryDirectory() as directory:
-            self.checker.prepare_directory(directory)
-            run_mock.assert_has_calls([
-                call('npm install --no-audit --no-fund', capture_output=True, check=True, cwd=directory, shell=True),
-            ])
+    def test_prepare_directory(self):
+        self.checker.prepare_directory(self.directory.name)
 
     def test_get_license_checker_command(self):
-        assert self.checker.get_license_checker_command() == 'npx license-checker --csv'
+        assert self.checker.get_license_checker_command() == './mvnw org.codehaus.mojo:license-maven-plugin:2.0.0:download-licenses'
 
     def test_parse_packages(self):
         packages = self.checker.parse_packages(self.DEMO_LICENSE_OUTPUT, Configuration(
             allowed_licenses=[],
             excluded_packages=[]
-        ), self.directory.name)
+        ))
         assert packages == [
             Package('xtend', '4.0.2', 'MIT'),
             Package('y18n', '4.0.0', 'ISC'),

--- a/tests/unit/test_npm.py
+++ b/tests/unit/test_npm.py
@@ -29,7 +29,7 @@ class TestNpmLicenseChecker:
             ])
 
     def test_get_license_checker_command(self):
-        assert self.checker.get_license_checker_command() == 'npx license-checker --csv'
+        assert self.checker.get_license_checker_command('') == 'npx license-checker --csv'
 
     def test_parse_packages(self):
         packages = self.checker.parse_packages(self.DEMO_LICENSE_OUTPUT, Configuration(

--- a/tests/unit/test_pipenv.py
+++ b/tests/unit/test_pipenv.py
@@ -47,7 +47,7 @@ class TestPipenvLicenseChecker:
 
     def test_parse_packages(self):
         configuration = Configuration()
-        packages = self.checker.parse_packages(self.DEMO_LICENSE_OUTPUT, configuration)
+        packages = self.checker.parse_packages(self.DEMO_LICENSE_OUTPUT, configuration, self.directory.name)
         assert packages == [
             Package('starlette', '0.14.1', 'BSD License'),
             Package('demo1234', '0.14.1', 'GPL'),

--- a/tests/unit/test_pipenv.py
+++ b/tests/unit/test_pipenv.py
@@ -43,7 +43,7 @@ class TestPipenvLicenseChecker:
         self.checker = PipenvLicenseChecker()
 
     def test_get_license_checker_command(self):
-        assert self.checker.get_license_checker_command() == 'pipenv run pip-licenses --format=json'
+        assert self.checker.get_license_checker_command('') == 'pipenv run pip-licenses --format=json'
 
     def test_parse_packages(self):
         configuration = Configuration()


### PR DESCRIPTION
This PR adds a new hook named `license-check-maven` that checks dependecies in a maven `pom.xml`.